### PR TITLE
feat(json): Implement export to JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,16 +275,56 @@ ecoindex-cli report "/tmp/ecoindex-cli/output/www.ecoindex.fr/2021-05-06_191355/
 
 ## Results example
 
-The result of the analysis is a CSV file which can be easily used for further analysis:
+The result of the analysis is a CSV or JSON file which can be easily used for further analysis:
+
+### CSV example
 
 ```csv
-size,nodes,requests,grade,score,ges,water,url,date,resolution,page_type
-119.095,45,8,A,89,1.22,1.83,http://www.ecoindex.fr,2021-04-20 16:45:28.570179,"1920,1080",
-769.252,730,94,D,41,2.18,3.27,https://www.greenit.fr/,2021-04-20 16:45:32.199242,"1920,1080",website
+width,height,url,size,nodes,requests,grade,score,ges,water,date,page_type
+1920,1080,http://www.ecoindex.fr,521.54,45,68,B,75.0,1.5,2.25,2022-05-03 22:28:49.280479,
+1920,1080,https://www.greenit.fr,1374.641,666,167,E,32.0,2.36,3.54,2022-05-03 22:28:51.176216,website
 ```
 
-Where:
+### JSON example
 
+```json
+[
+    {
+        "width": 1920,
+        "height": 1080,
+        "url": "http://www.ecoindex.fr",
+        "size": 521.54,
+        "nodes": 45,
+        "requests": 68,
+        "grade": "B",
+        "score": 75.0,
+        "ges": 1.5,
+        "water": 2.25,
+        "date": "2022-05-03 22:25:01.016749",
+        "page_type": null
+    },
+    {
+        "width": 1920,
+        "height": 1080,
+        "url": "https://www.greenit.fr",
+        "size": 1163.386,
+        "nodes": 666,
+        "requests": 148,
+        "grade": "E",
+        "score": 34.0,
+        "ges": 2.32,
+        "water": 3.48,
+        "date": "2022-05-03 22:25:04.516676",
+        "page_type": "website"
+    }
+]
+```
+
+### Fields description
+
+- `width` is the screen width used for the page analysis (in pixels)
+- `height` is the screen height used for the page analysis (in pixels)
+- `url` is the analysed page url
 - `size` is the size of the page and of the downloaded elements of the page in KB
 - `nodes` is the number of the DOM elements in the page
 - `requests` is the number of external requests made by the page
@@ -292,9 +332,7 @@ Where:
 - `score` is the corresponding ecoindex score of the page (0 to 100)
 - `ges` is the equivalent of greenhouse gases emission (in `gCO2e`) of the page
 - `water`is the equivalent water consumption (in `cl`) of the page
-- `url` is the analysed page url
 - `date` is the datetime of the page analysis
-- `resolution` is the screen resolution used for the page analysis (`width,height`)
 - `page_type` is the type of the page, based ton the [opengraph type tag](https://ogp.me/#types)
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -94,6 +94,26 @@ Processing  [####################################]  100%
 
 </details>
 
+### Export to JSON file
+
+By default, the results are exported to a CSV file. But, you can specify to export the results to a JSON file.
+
+```bash
+ecoindex-cli analyze --url http://www.ecoindex.fr --export-format json
+```
+
+<details><summary>Result</summary>
+
+```bash
+📁️ Urls recorded in file `input/www.ecoindex.fr.csv`
+There are 1 url(s), do you want to process? [Y/n]:
+1 urls for 1 window size with 2 maximum workers
+Processing  [####################################]  100%
+🙌️ File /tmp/ecoindex-cli/output/www.ecoindex.fr/2022-03-05_215320/results.json written !
+```
+
+</details>
+
 ### Multiple url analysis
 
 ```bash

--- a/ecoindex_cli/cli/app.py
+++ b/ecoindex_cli/cli/app.py
@@ -59,9 +59,8 @@ def analyze(
         help="You can define the number of workers to use for the analysis. Default is the number of cpu cores",
     ),
     export_format: Optional[ExportFormat] = Option(
-        default=ExportFormat.csv,
+        default=ExportFormat.csv.value,
         help="You can export the results in json or csv. Default is csv",
-        case_sensitive=False,
     ),
 ):
     """

--- a/ecoindex_cli/cli/app.py
+++ b/ecoindex_cli/cli/app.py
@@ -61,6 +61,7 @@ def analyze(
     export_format: Optional[ExportFormat] = Option(
         default=ExportFormat.csv.value,
         help="You can export the results in json or csv. Default is csv",
+        case_sensitive=False,
     ),
 ):
     """

--- a/ecoindex_cli/cli/app.py
+++ b/ecoindex_cli/cli/app.py
@@ -16,6 +16,7 @@ from ecoindex_cli.cli.arguments_handler import (
     get_window_sizes_from_args,
 )
 from ecoindex_cli.cli.helper import run_page_analysis
+from ecoindex_cli.enums import ExportFormat
 from ecoindex_cli.files import write_results_to_file, write_urls_to_file
 from ecoindex_cli.logger import Logger
 from ecoindex_cli.report.report import generate_report
@@ -56,6 +57,11 @@ def analyze(
     max_workers: Optional[int] = Option(
         default=None,
         help="You can define the number of workers to use for the analysis. Default is the number of cpu cores",
+    ),
+    export_format: Optional[ExportFormat] = Option(
+        default=ExportFormat.csv,
+        help="You can export the results in json or csv. Default is csv",
+        case_sensitive=False,
     ),
 ):
     """
@@ -163,14 +169,16 @@ def analyze(
     output_folder = (
         f"/tmp/ecoindex-cli/output/{file_prefix}/{time_now.strftime('%Y-%d-%m_%H%M%S')}"
     )
-    output_filename = f"{output_folder}/results.csv"
+    output_filename = f"{output_folder}/results.{export_format.value}"
 
     if output_file:
         output_filename = output_file
         output_folder = dirname(output_filename)
 
     Path(output_folder).mkdir(parents=True, exist_ok=True)
-    write_results_to_file(filename=output_filename, results=results)
+    write_results_to_file(
+        filename=output_filename, results=results, export_format=export_format
+    )
     secho(f"🙌️ File {output_filename} written !", fg=colors.GREEN)
     if html_report:
         generate_report(

--- a/ecoindex_cli/enums.py
+++ b/ecoindex_cli/enums.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class ExportFormat(Enum):
+    csv = "csv"
+    json = "json"

--- a/tests/ecoindex_cli/cli/test_app.py
+++ b/tests/ecoindex_cli/cli/test_app.py
@@ -91,3 +91,12 @@ def test_no_interaction():
     result = runner.invoke(app=app, args=["analyze", "--recursive", "--no-interaction"])
     assert "[Y/n]" not in result.stdout
     assert result.exit_code == 1
+
+
+def test_unauthorized_export_format():
+    result = runner.invoke(app=app, args=["analyze", "--export-format", "txt"])
+    assert result.exit_code == 2
+    assert (
+        "Error: Invalid value for '--export-format': 'txt' is not one of 'csv', 'json'."
+        in result.stdout
+    )


### PR DESCRIPTION
closes #130 

Add Enum option `--export-format`  : json | csv (default is csv)

Export json file example:
```json
[
    {
        "width": 1920,
        "height": 1080,
        "url": "http://www.ecoindex.fr",
        "size": 458.124,
        "nodes": 45,
        "requests": 67,
        "grade": "B",
        "score": 75.0,
        "ges": 1.5,
        "water": 2.25,
        "date": "2022-05-03 21:53:20.343810",
        "page_type": null
    }
]
```