### PR TITLE
👷 feat(docker): Add ARM 64 image to github action docker build push

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -1,6 +1,7 @@
 name: Publish Docker image
 
 on:
+  pull_request: ~
   release:
     types: [published]
 
@@ -34,7 +35,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          # platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
The goal of this PR is to provide a fully compatible docker image with arm64 architecture (Mac M1...)

# TODO

- [ ] Update the docker script to install chromium instead of google chrome (since google chrome is not compatible with arm64)
- [ ] Update install script to be able to know what is the current architecture
- [ ] Configure local docker buildx to test image building with arm64 architecture
- [ ] Update github action to enable building multi platform